### PR TITLE
fix for malformed message test

### DIFF
--- a/network/server_test.go
+++ b/network/server_test.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"testing"
 	"time"
-	"net"
 
 	"coinkit/currency"
 	"coinkit/util"
@@ -188,7 +188,7 @@ func checkForDeadSocket(c net.Conn) error {
 
 	// If our read timed out, let's try again until we get a definitive error.
 	if err, ok := err.(net.Error); ok && err.Timeout() {
-		 return checkForDeadSocket(c)
+		return checkForDeadSocket(c)
 	}
 
 	return err


### PR DESCRIPTION
There was a race between our attempted read from the socket and the TCP FIN stuff actually completing. So we'd get an i/o timeout instead of a definitive EOF error. The fix just keeps checking until the definitive error comes back.