### PR TITLE
Update testnet README

### DIFF
--- a/start-local.sh
+++ b/start-local.sh
@@ -7,7 +7,7 @@ if [ ! -d "$LOGS" ]; then
     exit 1
 fi
 
-if [[ `pwd | sed s/.*src//` != *coinkit ]]; then
+if [ `pwd | sed s/.*src//` != "/github.com/lacker/coinkit" ]; then
     echo "please run this from the coinkit directory"
     exit 1
 fi

--- a/start-local.sh
+++ b/start-local.sh
@@ -7,7 +7,7 @@ if [ ! -d "$LOGS" ]; then
     exit 1
 fi
 
-if [ `pwd | sed s/.*src//` != "/github.com/lacker/coinkit" ]; then
+if [[ `pwd | sed s/.*src//` != *coinkit ]]; then
     echo "please run this from the coinkit directory"
     exit 1
 fi
@@ -36,7 +36,7 @@ do
     ARGS="$ARGS --network=./local/network.json"
     ARGS="$ARGS --healthz=800$i"
     nohup cserver $ARGS &> $LOGS/cserver$i.log &
-done 
+done
 
 sleep 0.1
 ps aux | grep [^a-z]cserver | grep -v grep

--- a/testnet/README.md
+++ b/testnet/README.md
@@ -30,8 +30,8 @@ gcloud components install kubectl
 Choose a name for your gcloud coinkit project and create it:
 
 ```
-gcloud projects create your_coinkit_project_name
-gcloud config set project your_coinkit_project_name
+gcloud projects create your-coinkit-project-name
+gcloud config set project your-coinkit-project-name
 ```
 
 It is handy to have `PROJECT_ID` set to the name of your GCP project in your shell,

--- a/testnet/README.md
+++ b/testnet/README.md
@@ -128,6 +128,7 @@ service.yaml somehow instead
 
 XXX TRY:
 kubectl apply -f ./service.yaml
+
 XXX BUT:
 i'm pretty sure the labels are wrong. I don't know what they are
 supposed to be for, but I don't see how the service can attach to the deployment.

--- a/testnet/README.md
+++ b/testnet/README.md
@@ -27,19 +27,33 @@ Also use `gcloud` to install Kubernetes:
 gcloud components install kubectl
 ```
 
-My GCP project was named "coinkitalpha" and it seemed like Iowa "A" was the best place, so
-I set the `gcloud` defaults with:
+Choose a name for your gcloud coinkit project and create it:
 
 ```
-gcloud config set project coinkitalpha
-gcloud config set compute/zone us-central1-a
+gcloud projects create your_coinkit_project_name
+gcloud config set project your_coinkit_project_name
 ```
 
 It is handy to have `PROJECT_ID` set to the name of your GCP project in your shell,
-so add this to your bash config:
+so add this to your bash config and source it:
 
 ```
 export PROJECT_ID="$(gcloud config get-value project -q)"
+```
+
+It seemed like Iowa "A" was the best place, so I set the `gcloud` defaults with:
+
+```
+gcloud config set compute/zone us-central1-a
+```
+
+Enable billing for you project: https://cloud.google.com/billing/docs/how-to/modify-project
+
+Add `Kubernetes Engine` and `Container Registry` API access to your project:
+
+```
+gcloud services enable container.googleapis.com
+gcloud services enable containerregistry.googleapis.com
 ```
 
 ### 2. Install Docker
@@ -114,12 +128,11 @@ service.yaml somehow instead
 
 XXX TRY:
 kubectl apply -f ./service.yaml
-
 XXX BUT:
 i'm pretty sure the labels are wrong. I don't know what they are
 supposed to be for, but I don't see how the service can attach to the deployment.
 
-# XXX things dont work below here maybe
+# Bad instructions:
 
 Now we expose our deployment to the internet with a
 load balancer service named `loadbalancer`:

--- a/testnet/README.md
+++ b/testnet/README.md
@@ -47,7 +47,7 @@ It seemed like Iowa "A" was the best place, so I set the `gcloud` defaults with:
 gcloud config set compute/zone us-central1-a
 ```
 
-Enable billing for you project: https://cloud.google.com/billing/docs/how-to/modify-project
+Enable billing for your project: https://cloud.google.com/billing/docs/how-to/modify-project
 
 Add `Kubernetes Engine` and `Container Registry` API access to your project:
 
@@ -132,7 +132,7 @@ XXX BUT:
 i'm pretty sure the labels are wrong. I don't know what they are
 supposed to be for, but I don't see how the service can attach to the deployment.
 
-# Bad instructions:
+# XXX things dont work below here maybe
 
 Now we expose our deployment to the internet with a
 load balancer service named `loadbalancer`:


### PR DESCRIPTION
Adds a couple gcloud commands to enable `Kubernetes Engine` and `Container Registry Engine` APIs.

Also removes any mention of `coinkitalpha`, basically cause I tried to use that for my project name too, but those names are globally unique on gcloud.